### PR TITLE
Correction du dossier de déploiement pour la documentation Sphinx

### DIFF
--- a/.github/worflows/docs.yaml
+++ b/.github/worflows/docs.yaml
@@ -30,5 +30,5 @@ jobs:
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./docs/_build
+          publish_dir: ./docs/_build/current
 


### PR DESCRIPTION
Cette pull request met à jour le workflow GitHub Actions afin de déployer la version correcte de la documentation. Auparavant, le workflow pointait vers le dossier docs/_build, ce qui ne correspondait pas à la version actuelle de la documentation générée. Avec cette modification, le dossier utilisé pour le déploiement est désormais docs/_build/current.