### PR TITLE
Correction du lien cassé vers les contributeurs

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -32,7 +32,8 @@ Veuillez garder les  listes triées par **ordre alphabétique**.
 - Liliana Palma-Espinoza 
 - Louis Le Lay 
 - Marc-Antoine Lussier 
-- Marc-Olivier Bisson 
+- Marc-Olivier Bisson
+- Marie Hamady 
 - Mathieu Gagnon 
 - Mathias Bossaerts 
 - Margarita Pak 
@@ -42,6 +43,7 @@ Veuillez garder les  listes triées par **ordre alphabétique**.
 - Paul Joseph Beltran 
 - Pelayo García Seco 
 - Piero Castrillon Gamarra 
+- Pierre Teixeira
 - Robyn Girardeau 
 - Simon Prud'Homme 
 - Stacy-Linsay Octave 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -20,7 +20,7 @@ Pour plus de détails, consultez `BSD 3-Clause License
 Remerciements
 ^^^^^^^^^^^^^
 
-Merci aux membres de Naova pour toutes leurs contributions. Pour voir la liste complète des développeurs des projets de Naova, consultez le fichier `CONTRIBUTORS.md <(https://github.com/Naova/Naova.github.io/blob/main/CONTRIBUTORS.md>`_.
+Merci aux membres de Naova pour toutes leurs contributions. Pour voir la liste complète des développeurs des projets de Naova, consultez le fichier `CONTRIBUTORS.md <https://github.com/Naova/Naova.github.io/blob/main/CONTRIBUTORS.md>`_.
 
 Table des matieres
 ^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Correction du lien cassé vers le fichier contributors.md dans la documentation afin d'assurer une redirection correcte vers la liste des développeurs de Naova.