### PR TITLE
Corriger le workflow de déploiement pour ne cibler que la branche `main`

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,7 +1,10 @@
 name: Build and Deploy Sphinx Docs
 
-on: [push, workflow_dispatch]
-
+on:
+  push:
+    branches:
+      - main
+      
 permissions:
   contents: write
 


### PR DESCRIPTION
# Description

Le workflow GitHub Actions déployait la dernière branche poussée, quel que soit son nom.
Cette PR corrige ce comportement en restreignant le déploiement à la branche `main` uniquement lors d’un `push`.

Corrige : https://github.com/Naova/Naova.github.io/issues/37

## Checklist

- [x] Mes modifications ne génèrent aucun nouvel avertissement quand je lance le script de build.
- [ ] J'ai mis à jour le changelog et la version correspondante dans le fichier `config/extension.toml`.
- [x] J'ai ajouté mon nom dans le fichier `CONTRIBUTORS.md` (ou il y figure déjà).