### PR TITLE
Mise en place de la documentation versionnée

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -16,11 +16,14 @@ jobs:
         working-directory: ./docs
         run: pip install -r requirements.txt
 
-      - name: Build Sphinx Documentation
-        run: sphinx-build docs docs/_build
+      - name: Build Sphinx Documentation (Multi-Version)
+        run: sphinx-multiversion docs docs/_build/html
 
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./docs/_build/
+
+
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ Ce fichier suit les changements notables apportés à la documentation du projet
 
 ---
 
+## [1.0]
+### Ajouté
+- Fonction de génération multiversion de la documentation.
+- Support du tag Git `vX.0` uniquement.
+
+---
+
 ## [v0.1] - Unreleased
 
 ### Ajouté

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,41 @@
+# Changelog
+
+Ce fichier suit les changements notables apportés à la documentation du projet [Naova.github.io](https://github.com/Naova/Naova.github.io), selon le format `vx.y`.
+
+- `x` s'incrémente lors de **refontes majeures** (remplacement ou suppression d'une documentation existante pour un projet).
+- `y` s'incrémente à chaque **ajout**, **amélioration** ou **correction mineure** de contenu.
+
+---
+
+## [v0.1] - Unreleased
+
+### Ajouté
+- Création des pages d’installation, de configuration et des tutos de création de module.
+- Ajout d’un fichier `CONTRIBUTORS.md` et d’un `README.md`.
+- Mise en place de la structure `docs/` avec Sphinx.
+- Ajout d’un guide RST basique.
+- Pages de références initialisées (`additional_resources`, `bibliography`, `contributing`).
+- Début des sections `overview`, `projects`, `resources`, `how-to`.
+
+### Modifié
+- Traduction des titres de navigation en français.
+- Modification de l’apparence (changement du logo ÉTS par celui de Naova).
+- Réorganisation des pages (ressources, projets, etc.).
+- Amélioration de l’affichage de la page d’accueil et refonte légère de la structure des tutoriels.
+
+### Corrigé
+- Plusieurs fautes de frappe dans les pages.
+- Liens brisés dans `index.rst` et les pages de contribution.
+- Problème de branche dans le workflow de déploiement GitHub Actions.
+- Conditions de déclenchement du workflow de PR corrigées.
+
+---
+
+## [v0.0] - 2025-02-22
+
+### Ajouté
+- Initialisation du dépôt.
+- Première structure de site (fichiers `.rst`, configuration Sphinx).
+- Fichier `LICENSE`.
+
+---

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -195,15 +195,15 @@ templates_path = [
     "_templates",
 ]
 
-# Whitelist pattern for remotes
-smv_remote_whitelist = r"^.*$"
-# Whitelist pattern for branches (set to None to ignore all branches)
-smv_branch_whitelist = os.getenv("SMV_BRANCH_WHITELIST", r"^(main|devel)$")
-# Whitelist pattern for tags (set to None to ignore all tags)
-smv_tag_whitelist = os.getenv("SMV_TAG_WHITELIST", r"^v[1-9]\d*\.\d+\.\d+$")
-# html_sidebars = {
-#     "**": ["navbar-logo.html", "versioning.html", "icon-links.html", "search-field.html", "sbt-sidebar-nav.html"]
-# }
+smv_tag_whitelist = r'^v\d+\.0$'    # pour ne construire que les tags du type v1.0, v2.0 etc
+smv_branch_whitelist = r'^main$'    # pour ne construire que la branche main
+smv_remote_whitelist = r'^origin$'  # pour éviter les forks ou upstream
+
+html_context = {
+    'display_github': True,
+    'display_version': True,
+    'versions': []
+}
 
 html_sidebars = {
     "**": ["navbar-logo.html", "icon-links.html", "search-field.html", "sbt-sidebar-nav.html"]

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -70,6 +70,7 @@ Table des matieres
    source/refs/additional_resources
    source/refs/contributing
    source/refs/bibliography
+   source/refs/changelog
 
 .. toctree::
     :hidden:

--- a/docs/source/refs/bibliography.rst
+++ b/docs/source/refs/bibliography.rst
@@ -1,4 +1,4 @@
-.. bibliography:
+.. _bibliography:
 
 Bibliographie
 =============

--- a/docs/source/refs/changelog.rst
+++ b/docs/source/refs/changelog.rst
@@ -1,0 +1,7 @@
+.. _changelog:
+
+Changelog
+=========
+
+.. include:: ../../../CHANGELOG.md
+   :parser: markdown


### PR DESCRIPTION
# Description

Ajoute le support de la documentation multi-version pour permettre de consulter différentes versions du site selon les branches ou tags.

Corrige : https://github.com/Naova/Naova.github.io/issues/31

## Checklist

- [x] Mes modifications ne génèrent aucun nouvel avertissement quand je lance le script de build.
- [x] J'ai mis à jour le changelog et la version correspondante dans le fichier `config/extension.toml`.
- [x] J'ai ajouté mon nom dans le fichier `CONTRIBUTORS.md` (ou il y figure déjà).